### PR TITLE
feat: add GOROOT to `go mod download` if defined

### DIFF
--- a/resolve/driver/module.go
+++ b/resolve/driver/module.go
@@ -76,6 +76,9 @@ func (driver *pleaseDriver) ensureDownloaded(mod *packages.Module) (srcRoot stri
 
 	// Downlaod using `go mod download`
 	cmd := exec.Command("go", "mod", "download", "--json", key)
+	if goroot := os.Getenv("GOROOT"); goroot != "" {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", goroot))
+	}
 	cmd.Env = append(cmd.Env, fmt.Sprintf("GOPATH=%s", filepath.Join(wd, "plz-out/godeps/go")))
 	cmd.Dir = "plz-out/godeps"
 	progress.PrintUpdate("Downloading %s...", key)


### PR DESCRIPTION
`go mod download` require to have a GOROOT defined when go is not installed in `/usr/local/go`, or to use the version provided by `go_toolchain()`.

This change append the GOROOT env var to `go mod download`.